### PR TITLE
Support the setup of Typst v0.3.0+

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,27 +12,34 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Configure filenames (Linux)
-      run: |
-        echo "typst_asset_name=unknown-linux-gnu" >> $GITHUB_ENV
-        echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV
+    - name: Install Semver
+      run: npm install semver
       shell: bash
-      if: runner.os == 'Linux'
-    - name: Configure filenames (Windows)
+    - name: Configure filenames
       run: |
-        echo "typst_asset_name=pc-windows-msvc" >> $GITHUB_ENV
-        echo "typst_asset_zip_name=zip" >> $GITHUB_ENV
+        if [ "$RUNNER_OS" == 'Linux' ]; then
+          if semver -r '>=0.3.0' $inputs.version; then
+            echo "typst_asset_name=unknown-linux-musl" >> $GITHUB_ENV
+            echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
+          else
+            echo "typst_asset_name=unknown-linux-gnu" >> $GITHUB_ENV
+            echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV
+          fi
+        elif [ "$RUNNER_OS" == 'Windows' ]; then
+          echo "typst_asset_name=pc-windows-msvc" >> $GITHUB_ENV
+          echo "typst_asset_zip_name=zip" >> $GITHUB_ENV
+        else
+          echo "typst_asset_name=apple-darwin" >> $GITHUB_ENV
+          if semver -r '>=0.3.0' $inputs.version; then
+            echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
+          else
+            echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV
+          fi
+        fi
       shell: bash
-      if: runner.os == 'Windows'
-    - name: Configure filenames (macOS)
-      run: |
-        echo "typst_asset_name=apple-darwin" >> $GITHUB_ENV
-        echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV
-      shell: bash
-      if: runner.os == 'macOS'
 
     - name: Download release
-      uses: robinraju/release-downloader@v1.7
+      uses: robinraju/release-downloader@v1.8
       with:
         repository: typst/typst
         tag: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Unzip Typst (Linux, macOS)
       run: |
         sudo mkdir /usr/local/typst
-        ${{ format('sudo tar -xzf typst-x86_64-{0}.{1} -C /usr/local/typst/', env.typst_asset_name, env.typst_asset_zip_name) }}
+        ${{ format('sudo tar -xf typst-x86_64-{0}.{1} -C /usr/local/typst/', env.typst_asset_name, env.typst_asset_zip_name) }}
       shell: bash
       if: runner.os == 'Linux' || runner.os == 'macOS'
     - name: Unzip Typst (Windows)

--- a/action.yml
+++ b/action.yml
@@ -13,12 +13,12 @@ runs:
   using: composite
   steps:
     - name: Install Semver
-      run: npm install semver
+      run: npm install -g semver
       shell: bash
     - name: Configure filenames
       run: |
         if [ "$RUNNER_OS" == 'Linux' ]; then
-          if semver -r '>=0.3.0' $inputs.version; then
+          if semver -r '>=v0.3.0' $inputs.version; then
             echo "typst_asset_name=unknown-linux-musl" >> $GITHUB_ENV
             echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
           else
@@ -30,7 +30,7 @@ runs:
           echo "typst_asset_zip_name=zip" >> $GITHUB_ENV
         else
           echo "typst_asset_name=apple-darwin" >> $GITHUB_ENV
-          if semver -r '>=0.3.0' $inputs.version; then
+          if semver -r '>=v0.3.0' $inputs.version; then
             echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
           else
             echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -12,29 +12,17 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Install Semver
-      run: npm install -g semver
-      shell: bash
     - name: Configure filenames
       run: |
         if [ "$RUNNER_OS" == 'Linux' ]; then
-          if semver -r '>=v0.3.0' $inputs.version; then
-            echo "typst_asset_name=unknown-linux-musl" >> $GITHUB_ENV
-            echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
-          else
-            echo "typst_asset_name=unknown-linux-gnu" >> $GITHUB_ENV
-            echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV
-          fi
+          echo "typst_asset_name=unknown-linux-musl" >> $GITHUB_ENV
+          echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
         elif [ "$RUNNER_OS" == 'Windows' ]; then
           echo "typst_asset_name=pc-windows-msvc" >> $GITHUB_ENV
           echo "typst_asset_zip_name=zip" >> $GITHUB_ENV
         else
           echo "typst_asset_name=apple-darwin" >> $GITHUB_ENV
-          if semver -r '>=v0.3.0' $inputs.version; then
-            echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
-          else
-            echo "typst_asset_zip_name=tar.gz" >> $GITHUB_ENV
-          fi
+          echo "typst_asset_zip_name=tar.xz" >> $GITHUB_ENV
         fi
       shell: bash
 


### PR DESCRIPTION
_As Typst `v0.3.0` has adapted the Linux and macOS distribution filenames, the original action is not sufficient._

fix #8 

After this pull request has been merged, `v2.0` which is the new version of this action will be released. 

> **Warning**
> Setup Typst `v2.0` does not support Typst `v0.1.0` or `v0.2.0`.