### PR TITLE
Add `latest` tag for inputs.version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The token used to authenticate when fetching Typst distributions. When running t
 
 ### `version`
 
-Exact version of Typst to use.
+Exact version of Typst to use. Input `latest` if you want to use latest version of Typst.
 
 > **Warning**
 > Setup Typst `v2.0` does not support Typst `v0.1.0` or `v0.2.0`. If you want to use an old version, use [`v1`](https://github.com/yusancky/setup-typst/tree/v1).

--- a/action.yml
+++ b/action.yml
@@ -26,14 +26,22 @@ runs:
         fi
       shell: bash
 
+    - name: Download release if latest
+      uses: robinraju/release-downloader@v1.8
+      with:
+        repository: typst/typst
+        latest: true
+        fileName: ${{ format('typst-x86_64-{0}.{1}', env.typst_asset_name, env.typst_asset_zip_name) }}
+        token: ${{ inputs.token }}
+      if: inputs.version == 'latest'
     - name: Download release
       uses: robinraju/release-downloader@v1.8
       with:
         repository: typst/typst
-        tag: ${{ inputs.version != 'latest' ? inputs.version : "" }}
-        latest: ${{ inputs.version == 'latest' ? "true" : "false" }}
+        tag: ${{ inputs.version }}
         fileName: ${{ format('typst-x86_64-{0}.{1}', env.typst_asset_name, env.typst_asset_zip_name) }}
         token: ${{ inputs.token }}
+      if: inputs.version != 'latest'
 
     - name: Unzip Typst (Linux, macOS)
       run: |

--- a/action.yml
+++ b/action.yml
@@ -26,22 +26,14 @@ runs:
         fi
       shell: bash
 
-    - name: Download release if latest
-      uses: robinraju/release-downloader@v1.8
-      with:
-        repository: typst/typst
-        latest: true
-        fileName: ${{ format('typst-x86_64-{0}.{1}', env.typst_asset_name, env.typst_asset_zip_name) }}
-        token: ${{ inputs.token }}
-      if: inputs.version == 'latest'
     - name: Download release
       uses: robinraju/release-downloader@v1.8
       with:
         repository: typst/typst
-        tag: ${{ inputs.version }}
+        tag: ${{ inputs.version != 'latest' ? inputs.version : "" }}
+        latest: ${{ inputs.version == 'latest' ? "true" : "false" }}
         fileName: ${{ format('typst-x86_64-{0}.{1}', env.typst_asset_name, env.typst_asset_zip_name) }}
         token: ${{ inputs.token }}
-      if: inputs.version != 'latest'
 
     - name: Unzip Typst (Linux, macOS)
       run: |

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,14 @@ runs:
         fi
       shell: bash
 
+    - name: Download release if latest
+      uses: robinraju/release-downloader@v1.8
+      with:
+        repository: typst/typst
+        latest: true
+        fileName: ${{ format('typst-x86_64-{0}.{1}', env.typst_asset_name, env.typst_asset_zip_name) }}
+        token: ${{ inputs.token }}
+      if: inputs.version == 'latest'
     - name: Download release
       uses: robinraju/release-downloader@v1.8
       with:
@@ -33,6 +41,7 @@ runs:
         tag: ${{ inputs.version }}
         fileName: ${{ format('typst-x86_64-{0}.{1}', env.typst_asset_name, env.typst_asset_zip_name) }}
         token: ${{ inputs.token }}
+      if: inputs.version != 'latest'
 
     - name: Unzip Typst (Linux, macOS)
       run: |


### PR DESCRIPTION
Hi @yusancky, thanks for putting this useful action in place!

I'd suggest adding a `latest` tag for `inputs.version`, so that developers don't have to manually update the version number every time when Typst publishes a new release.
